### PR TITLE
verbose & debug options

### DIFF
--- a/index.js
+++ b/index.js
@@ -122,6 +122,9 @@ var tsPlugin = function(options) {
 
             // Compile
             console.log("Compiling..");
+            if (options.verbose) {
+                console.log(' compile cmd:', compileCmd)
+            }
 
             // shell.exec returns { code: , output: }
             // silent is set to true to prevent console output
@@ -153,15 +156,19 @@ var tsPlugin = function(options) {
                         // Last file has been read, and the directory can be cleaned out
                         // This assumes that the task is used with at least one file
                         if (options.out || filesRead === files.length) {
-                            rmdir(path.join(__dirname, compiledir), function (err) {
-                                if (err) {
-                                    throw err;
-                                }
-
-                                // Return buffers
+                            if (!options.debug) {
+                                rmdir(path.join(__dirname, compiledir), function (err) {
+                                    if (err) {
+                                        throw err;
+                                    }
+                                    // Return buffers
+                                    that.emit('end');
+                                    console.log("Compiling complete.");
+                                });
+                            } else {
+                                console.log('In debug mode, so compiledir was left for inspection.')
                                 that.emit('end');
-                            });
-                            that.emit('end');
+                            }
                         }
                     });
                 };

--- a/test/gulpfile.js
+++ b/test/gulpfile.js
@@ -23,3 +23,14 @@ gulp.task('singlefile', function(){
         }))
         .pipe(gulp.dest('out'));;
 });
+
+gulp.task('debug', function(){
+      gulp.src(['hello.ts', 'subfolder/hello3.ts'])
+        .pipe(ts({
+            module: 'commonjs',
+            removeComments: true,
+            verbose: true,
+            debug: true,
+        }))
+        .pipe(gulp.dest('out'));;
+});


### PR DESCRIPTION
can now specify { verbose: true, debug:true } for troubleshooting issues with gulp-ts or ts. Comes in handy for me!
