### PR TITLE
Add options to choose TypeScript compiler executable explicitly, update deps

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,12 @@ gulp.task('typescript', function() {
 Supports the following options.
 ```javascript
  .pipe(ts({
+  // explicit path to tsc executable file; taken if not falsy
+  exePath: '',
+
+  // forces usage of tsc executable file from system PATH
+  globalExe: false,
+
   // Generates corresponding .map file.
   sourceMap : false,
 
@@ -52,6 +58,6 @@ Supports the following options.
   sourceRoot : '',
 
   // Specifies the location where debugger should locate map files instead of generated locations.
-  mapRoot : '' 
+  mapRoot : ''
 }));
 ```

--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 /*jslint node:true */
 /*jslint nomen: true */
-"use strict";
+'use strict';
 
 /**
  * Requires
@@ -22,228 +22,247 @@ var shell = require('shelljs');
 // rm -rf for Node.js
 var rmdir = require('rimraf');
 
-var tsPlugin = function (options) {
-    var bufferFiles,
-        compileFiles,
-        handleDeclaration,
-        files = [],
-        // Files are compiled in this sub-directory
-        compiledir = 'compiledir';
+var tsPlugin = function(options) {
+  var bufferFiles,
+      compileFiles,
+      handleDeclaration,
+      files = [],
 
-    // Default options
-    if (!options) {
-        options = {};
+      // Files are compiled in this sub-directory
+      compiledir = 'compiledir';
+
+  // Default options
+  if (!options) {
+    options = {};
+  }
+
+  if (options.debug) {
+    options.verbose = true;
+  }
+
+  // Collect all files to an array
+  bufferFiles = function(file) {
+    // Null values and streams are skipped
+    if (file.isNull()) {
+      return;
     }
-    if (options.debug) {
-        options.verbose = true;
+
+    if (file.isStream()) {
+      return this.emit('error', new PluginError('gulp-ts',  'Streaming not supported'));
     }
 
-    // Collect all files to an array
-    bufferFiles = function (file) {
-        // Null values and streams are skipped
-        if (file.isNull()) {
-            return;
+    // Using path.relative doesn't seem safe, but we need the relative path
+    // to the 'base', e.g. if we have 'a.ts' and 'b/b.ts' from src, the relative
+    // property tells the path from cwd to path.
+    file.relativePath = path.relative(file.cwd, file.path);
+
+    // Add file to the list of source files
+    files.push(file);
+  };
+
+  // Compile all files defined in the files Array
+  compileFiles = function() {
+    // Construct a compile command to be used with the shell TypeScript compiler
+    var compileCmd = '',
+
+        // Path to the TypeScript binary
+        // TODO: We can't be certain about the location, find the path properly.
+        tscPath = path.join(__dirname, 'node_modules/typescript/bin/tsc'),
+        that = this,
+
+        // The number of files read and pushed as File objects
+        filesRead = 0,
+        globalExecutableUsed = false;
+
+    // If tsc doesn't exist in the local node_modules
+    if (options.global || !shell.test('-f', tscPath)) {
+      // Try to find tsc from the system PATH, returns falsy if not found
+      tscPath = shell.which('tsc');
+      globalExecutableUsed = true;
+    }
+
+    // tsc not found, abort
+    if (!tscPath) {
+      return this.emit('error', new PluginError('gulp-ts',
+          'Error, TypeScript compiler not found from node_modules or system PATH!\n'));
+    }
+
+    // Basic options
+    if (options.sourceMap) {
+      compileCmd += ' --sourceMap';
+    }
+
+    if (options.declaration) {
+      compileCmd += ' --declaration';
+    }
+
+    if (options.removeComments) {
+      compileCmd += ' --removeComments';
+    }
+
+    if (options.noImplicitAny) {
+      compileCmd += ' --noImplicitAny';
+    }
+
+    if (options.noResolve) {
+      compileCmd += ' --noResolve';
+    }
+
+    // Module option
+    compileCmd += ' --module ' + (options.module || 'amd').toLowerCase();
+
+    // Target ES3/ES5 option
+    compileCmd += ' --target ' + (options.target || 'ES3').toUpperCase();
+
+    // Output file option
+    if (options.out) {
+      compileCmd += ' --out ' + path.join(__dirname, compiledir, options.out);
+    } else {
+      // Compile all files to output directory. After compilation they're read to
+      // memory and the directory is destroyed. The reason for this 'hack' is that the
+      // TypeScript compiler doesn't easily support in-memory compilation.
+      // The use of --outDir for other means doesn't seem necessary.
+      compileCmd += ' --outDir ' + path.join(__dirname, compiledir);
+    }
+
+    // Source root option
+    if (options.sourceRoot) {
+      compileCmd += ' --sourceRoot ' + options.sourceRoot;
+    }
+
+    // Map root option
+    if (options.mapRoot) {
+      compileCmd += ' --mapRoot ' + options.mapRoot;
+    }
+
+    // Add source file full paths to the compile command
+    files.forEach(function(file) {
+      compileCmd += ' ' + file.path;
+    });
+
+    // Remove compiledir if it already exists
+    rmdir(path.join(__dirname, compiledir), function(err) {
+      // Remove failed
+      if (err) {
+        throw err;
+      }
+
+      // Compile
+      log('Compiling...');
+      if (options.verbose) {
+        log(' compile cmd:', compileCmd);
+      }
+
+      // shell.exec returns { code: , output: }
+      // silent is set to true to prevent console output
+      var command = (globalExecutableUsed ? '' : '"' + process.execPath + '" ') +
+        '"' +  tscPath + '"' +
+        compileCmd;
+      shell.exec(command, { silent: true }, function(code, output) {
+        if (options.debug) {
+          log(' tsc output: [', output, ']');
         }
-        if (file.isStream()) {
-            return this.emit('error', new PluginError('gulp-ts',  'Streaming not supported'));
+
+        if (code) {
+          return that.emit('error', new PluginError('gulp-ts',
+              'Error during compilation!\n\n' + output));
         }
 
-        // Using path.relative doesn't seem safe, but we need the relative path
-        // to the 'base', e.g. if we have 'a.ts' and 'b/b.ts' from src, the relative
-        // property tells the path from cwd to path.
-        file.relativePath = path.relative(file.cwd, file.path);
-
-        // Add file to the list of source files
-        files.push(file);
-    };
-
-    // Compile all files defined in the files Array
-    compileFiles = function () {
-        // Construct a compile command to be used with the shell TypeScript compiler
-        var compileCmd = '',
-            // Path to the TypeScript binary
-            // TODO: We can't be certain about the location, find the path properly.
-            tscPath = path.join(__dirname, 'node_modules/typescript/bin/tsc'),
-            that = this,
-            // The number of files read and pushed as File objects
-            filesRead = 0;
-
-        // If tsc doesn't exist in the local node_modules
-        if (!shell.test('-f', tscPath)) {
-            // Try to find tsc from the system PATH, returns falsy if not found
-            tscPath = shell.which('tsc');
-        }
-
-        // tsc not found, abort
-        if (!tscPath) {
-            return this.emit('error', new PluginError('gulp-ts',
-                'Error, TypeScript compiler not found from node_modules or system PATH!\n'));
-        }
-
-        // Basic options
-        if (options.sourceMap) {
-            compileCmd += ' --sourceMap';
-        }
-        if (options.declaration) {
-            compileCmd += ' --declaration';
-        }
-        if (options.removeComments) {
-            compileCmd += ' --removeComments';
-        }
-        if (options.noImplicitAny) {
-            compileCmd += ' --noImplicitAny';
-        }
-        if (options.noResolve) {
-            compileCmd += ' --noResolve';
-        }
-
-        // Module option
-        compileCmd += ' --module ' + (options.module || 'amd').toLowerCase();
-
-        // Target ES3/ES5 option
-        compileCmd += ' --target ' + (options.target || 'ES3').toUpperCase();
-
-        // Output file option
-        if (options.out) {
-            compileCmd += ' --out ' + path.join(__dirname, compiledir, options.out);
-        } else {
-            // Compile all files to output directory. After compilation they're read to
-            // memory and the directory is destroyed. The reason for this 'hack' is that the
-            // TypeScript compiler doesn't easily support in-memory compilation.
-            // The use of --outDir for other means doesn't seem necessary.
-            compileCmd += ' --outDir ' + path.join(__dirname, compiledir);
-        }
-
-        // Source root option
-        if (options.sourceRoot) {
-            compileCmd += ' --sourceRoot ' + options.sourceRoot;
-        }
-
-        // Map root option
-        if (options.mapRoot) {
-            compileCmd += ' --mapRoot ' + options.mapRoot;
-        }
-
-        // Add source file full paths to the compile command
-        files.forEach(function (file) {
-            compileCmd += ' ' + file.path;
-        });
-
-        // Remove compiledir if it already exists
-        rmdir(path.join(__dirname, compiledir), function (err) {
-            // Remove failed
+        var readSourceFile = function(relativePath, cwd, base) {
+          // Read from compiledir and replace .ts -> .js
+          fs.readFile(path.join(__dirname, compiledir, relativePath.replace('.ts', '.js')), function(err, data) {
+            // Read failed
             if (err) {
-                throw err;
+              throw err;
             }
 
-            // Compile
-            log('Compiling...');
-            if (options.verbose) {
-                log(' compile cmd:', compileCmd);
-            }
+            // Issue: Gulp flattens the output directory
+            // https://github.com/panuhorsmalahti/gulp-ts/issues/2
+            that.push(new File({
+              cwd: cwd,
+              base: base,
+              path: path.join(cwd, relativePath.replace('.ts', '.js')),
+              contents: data,
+            }));
 
-            // shell.exec returns { code: , output: }
-            // silent is set to true to prevent console output
-            shell.exec(process.execPath + ' ' + tscPath + compileCmd, { silent: true }, function (code, output) {
-                if (options.debug) {
-                    log(' tsc output: [', output, ']');
-                }
-                if (code) {
-                    return that.emit('error', new PluginError('gulp-ts',
-                        'Error during compilation!\n\n' + output));
-                }
+            // Increase file counter
+            filesRead += 1;
 
-                var readSourceFile = function (relativePath, cwd, base) {
-                    // Read from compiledir and replace .ts -> .js
-                    fs.readFile(path.join(__dirname, compiledir, relativePath.replace('.ts', '.js')), function (err, data) {
-                        // Read failed
-                        if (err) {
-                            throw err;
-                        }
-
-                        // Issue: Gulp flattens the output directory
-                        // https://github.com/panuhorsmalahti/gulp-ts/issues/2
-                        that.push(new File({
-                            cwd: cwd,
-                            base: base,
-                            path: path.join(cwd, relativePath.replace('.ts', '.js')),
-                            contents: data
-                        }));
-
-                        // Increase file counter
-                        filesRead += 1;
-
-                        // Last file has been read, and the directory can be cleaned out.
-                        // This assumes that the task is used with at least one file.
-                        if (options.out || filesRead === files.length) {
-                            if (!options.debug) {
-                                rmdir(path.join(__dirname, compiledir), function (err) {
-                                    if (err) {
-                                        throw err;
-                                    }
-                                    // Return buffers
-                                    that.emit('end');
-                                    log('Compiling complete.');
-                                });
-                            } else {
-                                log('In debug mode, so compiledir was left for inspection.');
-                                that.emit('end');
-                            }
-                        }
-                    });
-                };
-
-                // Read output files
-                handleDeclaration.call(that, function () {
-                    if (options.out) {
-                        readSourceFile(options.out, '/', '/');
-                    } else {
-                        files.forEach(function (file) {
-                            readSourceFile(file.relativePath, file.cwd, file.base);
-                        });
-                    }
-                });
-            });
-        });
-    };
-
-    // Handles buffering the declaration file if necessary.
-    handleDeclaration = function (callback) {
-        var that = this,
-            srcPath, // relative path to file generated from tsc
-            cwd = process.cwd(),
-            fileConfig;
-
-        if (options.declaration) {
-            // NOTE: The declaration file generated by tsc is the same as the out file specified with --out or
-            // it seems it is the name of the root source file
-            if (options.out) {
-                srcPath = options.out.replace('.js', '.d.ts');
-            } else {
-                srcPath = files[0].path.replace('.ts', '.d.ts');
-            }
-            srcPath = path.relative(cwd, srcPath);
-            // Read the generated file
-            fs.readFile(path.join(__dirname, compiledir, srcPath), function (err, data) {
-                if (err) {
+            // Last file has been read, and the directory can be cleaned out.
+            // This assumes that the task is used with at least one file.
+            if (options.out || filesRead === files.length) {
+              if (!options.debug) {
+                rmdir(path.join(__dirname, compiledir), function(err) {
+                  if (err) {
                     throw err;
-                }
-                // Buffer the file
-                fileConfig = {
-                    base: path.dirname(srcPath),
-                    path: srcPath,
-                    contents: data
-                };
-                that.push(new File(fileConfig));
-                callback();
-            });
-        } else {
-            callback();
-        }
-    };
+                  }
 
-    // bufferFiles is executed once per each file, compileFiles is called once at the end
-    return through(bufferFiles, compileFiles);
+                  // Return buffers
+                  that.emit('end');
+                  log('Compiling complete.');
+                });
+              } else {
+                log('In debug mode, so compiledir was left for inspection.');
+                that.emit('end');
+              }
+            }
+          });
+        };
+
+        // Read output files
+        handleDeclaration.call(that, function() {
+          if (options.out) {
+            readSourceFile(options.out, '/', '/');
+          } else {
+            files.forEach(function(file) {
+              readSourceFile(file.relativePath, file.cwd, file.base);
+            });
+          }
+        });
+      });
+    });
+  };
+
+  // Handles buffering the declaration file if necessary.
+  handleDeclaration = function(callback) {
+    var that = this,
+        srcPath, // relative path to file generated from tsc
+        cwd = process.cwd(),
+        fileConfig;
+
+    if (options.declaration) {
+      // NOTE: The declaration file generated by tsc is the same as the out file specified with --out or
+      // it seems it is the name of the root source file
+      if (options.out) {
+        srcPath = options.out.replace('.js', '.d.ts');
+      } else {
+        srcPath = files[0].path.replace('.ts', '.d.ts');
+      }
+
+      srcPath = path.relative(cwd, srcPath);
+
+      // Read the generated file
+      fs.readFile(path.join(__dirname, compiledir, srcPath), function(err, data) {
+        if (err) {
+          throw err;
+        }
+
+        // Buffer the file
+        fileConfig = {
+          base: path.dirname(srcPath),
+          path: srcPath,
+          contents: data,
+        };
+        that.push(new File(fileConfig));
+        callback();
+      });
+    } else {
+      callback();
+    }
+  };
+
+  // bufferFiles is executed once per each file, compileFiles is called once at the end
+  return through(bufferFiles, compileFiles);
 };
 
 module.exports = tsPlugin;

--- a/index.js
+++ b/index.js
@@ -64,10 +64,9 @@ var tsPlugin = function(options) {
   compileFiles = function() {
     // Construct a compile command to be used with the shell TypeScript compiler
     var compileCmd = '',
-
         // Path to the TypeScript binary
         // TODO: We can't be certain about the location, find the path properly.
-        tscPath = path.join(__dirname, 'node_modules/typescript/bin/tsc'),
+        tscPath = options.exePath || path.join(__dirname, 'node_modules/typescript/bin/tsc'),
         that = this,
 
         // The number of files read and pushed as File objects
@@ -75,7 +74,8 @@ var tsPlugin = function(options) {
         globalExecutableUsed = false;
 
     // If tsc doesn't exist in the local node_modules
-    if (options.global || !shell.test('-f', tscPath)) {
+    if (options.global || !shell.test('-f', tscPath)
+    ) {
       // Try to find tsc from the system PATH, returns falsy if not found
       tscPath = shell.which('tsc');
       globalExecutableUsed = true;

--- a/index.js
+++ b/index.js
@@ -3,8 +3,8 @@
 'use strict';
 
 /**
- * Requires
- */
+  * Requires
+  */
 
 // Native
 var fs = require('fs');
@@ -22,247 +22,246 @@ var shell = require('shelljs');
 // rm -rf for Node.js
 var rmdir = require('rimraf');
 
-var tsPlugin = function(options) {
-  var bufferFiles,
-      compileFiles,
-      handleDeclaration,
-      files = [],
+var tsPlugin = function (options) {
+    var bufferFiles,
+        compileFiles,
+        handleDeclaration,
+        files = [],
 
-      // Files are compiled in this sub-directory
-      compiledir = 'compiledir';
+        // Files are compiled in this sub-directory
+        compiledir = 'compiledir';
 
-  // Default options
-  if (!options) {
-    options = {};
-  }
-
-  if (options.debug) {
-    options.verbose = true;
-  }
-
-  // Collect all files to an array
-  bufferFiles = function(file) {
-    // Null values and streams are skipped
-    if (file.isNull()) {
-      return;
+    // Default options
+    if (!options) {
+        options = {};
     }
 
-    if (file.isStream()) {
-      return this.emit('error', new PluginError('gulp-ts',  'Streaming not supported'));
+    if (options.debug) {
+        options.verbose = true;
     }
 
-    // Using path.relative doesn't seem safe, but we need the relative path
-    // to the 'base', e.g. if we have 'a.ts' and 'b/b.ts' from src, the relative
-    // property tells the path from cwd to path.
-    file.relativePath = path.relative(file.cwd, file.path);
-
-    // Add file to the list of source files
-    files.push(file);
-  };
-
-  // Compile all files defined in the files Array
-  compileFiles = function() {
-    // Construct a compile command to be used with the shell TypeScript compiler
-    var compileCmd = '',
-        // Path to the TypeScript binary
-        // TODO: We can't be certain about the location, find the path properly.
-        tscPath = options.exePath || path.join(__dirname, 'node_modules/typescript/bin/tsc'),
-        that = this,
-
-        // The number of files read and pushed as File objects
-        filesRead = 0,
-        globalExecutableUsed = false;
-
-    // If tsc doesn't exist in the local node_modules
-    if (options.global || !shell.test('-f', tscPath)
-    ) {
-      // Try to find tsc from the system PATH, returns falsy if not found
-      tscPath = shell.which('tsc');
-      globalExecutableUsed = true;
-    }
-
-    // tsc not found, abort
-    if (!tscPath) {
-      return this.emit('error', new PluginError('gulp-ts',
-          'Error, TypeScript compiler not found from node_modules or system PATH!\n'));
-    }
-
-    // Basic options
-    if (options.sourceMap) {
-      compileCmd += ' --sourceMap';
-    }
-
-    if (options.declaration) {
-      compileCmd += ' --declaration';
-    }
-
-    if (options.removeComments) {
-      compileCmd += ' --removeComments';
-    }
-
-    if (options.noImplicitAny) {
-      compileCmd += ' --noImplicitAny';
-    }
-
-    if (options.noResolve) {
-      compileCmd += ' --noResolve';
-    }
-
-    // Module option
-    compileCmd += ' --module ' + (options.module || 'amd').toLowerCase();
-
-    // Target ES3/ES5 option
-    compileCmd += ' --target ' + (options.target || 'ES3').toUpperCase();
-
-    // Output file option
-    if (options.out) {
-      compileCmd += ' --out ' + path.join(__dirname, compiledir, options.out);
-    } else {
-      // Compile all files to output directory. After compilation they're read to
-      // memory and the directory is destroyed. The reason for this 'hack' is that the
-      // TypeScript compiler doesn't easily support in-memory compilation.
-      // The use of --outDir for other means doesn't seem necessary.
-      compileCmd += ' --outDir ' + path.join(__dirname, compiledir);
-    }
-
-    // Source root option
-    if (options.sourceRoot) {
-      compileCmd += ' --sourceRoot ' + options.sourceRoot;
-    }
-
-    // Map root option
-    if (options.mapRoot) {
-      compileCmd += ' --mapRoot ' + options.mapRoot;
-    }
-
-    // Add source file full paths to the compile command
-    files.forEach(function(file) {
-      compileCmd += ' ' + file.path;
-    });
-
-    // Remove compiledir if it already exists
-    rmdir(path.join(__dirname, compiledir), function(err) {
-      // Remove failed
-      if (err) {
-        throw err;
-      }
-
-      // Compile
-      log('Compiling...');
-      if (options.verbose) {
-        log(' compile cmd:', compileCmd);
-      }
-
-      // shell.exec returns { code: , output: }
-      // silent is set to true to prevent console output
-      var command = (globalExecutableUsed ? '' : '"' + process.execPath + '" ') +
-        '"' +  tscPath + '"' +
-        compileCmd;
-      shell.exec(command, { silent: true }, function(code, output) {
-        if (options.debug) {
-          log(' tsc output: [', output, ']');
+    // Collect all files to an array
+    bufferFiles = function (file) {
+        // Null values and streams are skipped
+        if (file.isNull()) {
+            return;
         }
 
-        if (code) {
-          return that.emit('error', new PluginError('gulp-ts',
-              'Error during compilation!\n\n' + output));
+        if (file.isStream()) {
+            return this.emit('error', new PluginError('gulp-ts',  'Streaming not supported'));
         }
 
-        var readSourceFile = function(relativePath, cwd, base) {
-          // Read from compiledir and replace .ts -> .js
-          fs.readFile(path.join(__dirname, compiledir, relativePath.replace('.ts', '.js')), function(err, data) {
-            // Read failed
-            if (err) {
-              throw err;
-            }
+        // Using path.relative doesn't seem safe, but we need the relative path
+        // to the 'base', e.g. if we have 'a.ts' and 'b/b.ts' from src, the relative
+        // property tells the path from cwd to path.
+        file.relativePath = path.relative(file.cwd, file.path);
 
-            // Issue: Gulp flattens the output directory
-            // https://github.com/panuhorsmalahti/gulp-ts/issues/2
-            that.push(new File({
-              cwd: cwd,
-              base: base,
-              path: path.join(cwd, relativePath.replace('.ts', '.js')),
-              contents: data,
-            }));
+        // Add file to the list of source files
+        files.push(file);
+    };
 
-            // Increase file counter
-            filesRead += 1;
+    // Compile all files defined in the files Array
+    compileFiles = function () {
+        // Construct a compile command to be used with the shell TypeScript compiler
+        var compileCmd = '',
+            // Path to the TypeScript binary
+            // We can't be certain about the location, find the path properly.
+            tscPath = options.exePath || path.join(__dirname, 'node_modules/typescript/bin/tsc'),
+            that = this,
 
-            // Last file has been read, and the directory can be cleaned out.
-            // This assumes that the task is used with at least one file.
-            if (options.out || filesRead === files.length) {
-              if (!options.debug) {
-                rmdir(path.join(__dirname, compiledir), function(err) {
-                  if (err) {
-                    throw err;
-                  }
+            // The number of files read and pushed as File objects
+            filesRead = 0,
+            globalExecutableUsed = false;
 
-                  // Return buffers
-                  that.emit('end');
-                  log('Compiling complete.');
-                });
-              } else {
-                log('In debug mode, so compiledir was left for inspection.');
-                that.emit('end');
-              }
-            }
-          });
-        };
+        // If tsc doesn't exist in the local node_modules
+        if (options.global || !shell.test('-f', tscPath)) {
+            // Try to find tsc from the system PATH, returns falsy if not found
+            tscPath = shell.which('tsc');
+            globalExecutableUsed = true;
+        }
 
-        // Read output files
-        handleDeclaration.call(that, function() {
-          if (options.out) {
-            readSourceFile(options.out, '/', '/');
-          } else {
-            files.forEach(function(file) {
-              readSourceFile(file.relativePath, file.cwd, file.base);
-            });
-          }
+        // tsc not found, abort
+        if (!tscPath) {
+            return this.emit('error', new PluginError('gulp-ts',
+                    'Error, TypeScript compiler not found from node_modules or system PATH!\n'));
+        }
+
+        // Basic options
+        if (options.sourceMap) {
+            compileCmd += ' --sourceMap';
+        }
+
+        if (options.declaration) {
+            compileCmd += ' --declaration';
+        }
+
+        if (options.removeComments) {
+            compileCmd += ' --removeComments';
+        }
+
+        if (options.noImplicitAny) {
+            compileCmd += ' --noImplicitAny';
+        }
+
+        if (options.noResolve) {
+            compileCmd += ' --noResolve';
+        }
+
+        // Module option
+        compileCmd += ' --module ' + (options.module || 'amd').toLowerCase();
+
+        // Target ES3/ES5 option
+        compileCmd += ' --target ' + (options.target || 'ES3').toUpperCase();
+
+        // Output file option
+        if (options.out) {
+            compileCmd += ' --out ' + path.join(__dirname, compiledir, options.out);
+        } else {
+            // Compile all files to output directory. After compilation they're read to
+            // memory and the directory is destroyed. The reason for this 'hack' is that the
+            // TypeScript compiler doesn't easily support in-memory compilation.
+            // The use of --outDir for other means doesn't seem necessary.
+            compileCmd += ' --outDir ' + path.join(__dirname, compiledir);
+        }
+
+        // Source root option
+        if (options.sourceRoot) {
+            compileCmd += ' --sourceRoot ' + options.sourceRoot;
+        }
+
+        // Map root option
+        if (options.mapRoot) {
+            compileCmd += ' --mapRoot ' + options.mapRoot;
+        }
+
+        // Add source file full paths to the compile command
+        files.forEach(function (file) {
+            compileCmd += ' ' + file.path;
         });
-      });
-    });
-  };
 
-  // Handles buffering the declaration file if necessary.
-  handleDeclaration = function(callback) {
-    var that = this,
-        srcPath, // relative path to file generated from tsc
-        cwd = process.cwd(),
-        fileConfig;
+        // Remove compiledir if it already exists
+        rmdir(path.join(__dirname, compiledir), function (err) {
+            // Remove failed
+            if (err) {
+                throw err;
+            }
 
-    if (options.declaration) {
-      // NOTE: The declaration file generated by tsc is the same as the out file specified with --out or
-      // it seems it is the name of the root source file
-      if (options.out) {
-        srcPath = options.out.replace('.js', '.d.ts');
-      } else {
-        srcPath = files[0].path.replace('.ts', '.d.ts');
-      }
+            // Compile
+            log('Compiling...');
+            if (options.verbose) {
+                log(' compile cmd:', compileCmd);
+            }
 
-      srcPath = path.relative(cwd, srcPath);
+            // shell.exec returns { code: , output: }
+            // silent is set to true to prevent console output
+            var command = (globalExecutableUsed ? '' : '"' + process.execPath + '" ') +
+                '"' +  tscPath + '"' +
+                compileCmd;
+            shell.exec(command, { silent: true }, function (code, output) {
+                if (options.debug) {
+                    log(' tsc output: [', output, ']');
+                }
 
-      // Read the generated file
-      fs.readFile(path.join(__dirname, compiledir, srcPath), function(err, data) {
-        if (err) {
-          throw err;
+                if (code) {
+                    return that.emit('error', new PluginError('gulp-ts',
+                            'Error during compilation!\n\n' + output));
+                }
+
+                var readSourceFile = function (relativePath, cwd, base) {
+                    // Read from compiledir and replace .ts -> .js
+                    fs.readFile(path.join(__dirname, compiledir, relativePath.replace('.ts', '.js')), function (err, data) {
+                        // Read failed
+                        if (err) {
+                            throw err;
+                        }
+
+                        // Issue: Gulp flattens the output directory
+                        // https://github.com/panuhorsmalahti/gulp-ts/issues/2
+                        that.push(new File({
+                            cwd: cwd,
+                            base: base,
+                            path: path.join(cwd, relativePath.replace('.ts', '.js')),
+                            contents: data,
+                        }));
+
+                        // Increase file counter
+                        filesRead += 1;
+
+                        // Last file has been read, and the directory can be cleaned out.
+                        // This assumes that the task is used with at least one file.
+                        if (options.out || filesRead === files.length) {
+                            if (!options.debug) {
+                                rmdir(path.join(__dirname, compiledir), function (err) {
+                                    if (err) {
+                                        throw err;
+                                    }
+
+                                    // Return buffers
+                                    that.emit('end');
+                                    log('Compiling complete.');
+                                });
+                            } else {
+                                log('In debug mode, so compiledir was left for inspection.');
+                                that.emit('end');
+                            }
+                        }
+                    });
+                };
+
+                // Read output files
+                handleDeclaration.call(that, function () {
+                    if (options.out) {
+                        readSourceFile(options.out, '/', '/');
+                    } else {
+                        files.forEach(function (file) {
+                            readSourceFile(file.relativePath, file.cwd, file.base);
+                        });
+                    }
+                });
+            });
+        });
+    };
+
+    // Handles buffering the declaration file if necessary.
+    handleDeclaration = function (callback) {
+        var that = this,
+            srcPath, // relative path to file generated from tsc
+            cwd = process.cwd(),
+            fileConfig;
+
+        if (options.declaration) {
+            // NOTE: The declaration file generated by tsc is the same as the out file specified with --out or
+            // it seems it is the name of the root source file
+            if (options.out) {
+                srcPath = options.out.replace('.js', '.d.ts');
+            } else {
+                srcPath = files[0].path.replace('.ts', '.d.ts');
+            }
+
+            srcPath = path.relative(cwd, srcPath);
+
+            // Read the generated file
+            fs.readFile(path.join(__dirname, compiledir, srcPath), function (err, data) {
+                if (err) {
+                    throw err;
+                }
+
+                // Buffer the file
+                fileConfig = {
+                    base: path.dirname(srcPath),
+                    path: srcPath,
+                    contents: data,
+                };
+                that.push(new File(fileConfig));
+                callback();
+            });
+        } else {
+            callback();
         }
+    };
 
-        // Buffer the file
-        fileConfig = {
-          base: path.dirname(srcPath),
-          path: srcPath,
-          contents: data,
-        };
-        that.push(new File(fileConfig));
-        callback();
-      });
-    } else {
-      callback();
-    }
-  };
-
-  // bufferFiles is executed once per each file, compileFiles is called once at the end
-  return through(bufferFiles, compileFiles);
+    // bufferFiles is executed once per each file, compileFiles is called once at the end
+    return through(bufferFiles, compileFiles);
 };
 
 module.exports = tsPlugin;

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "gulp-ts",
   "preferGlobal": false,
-  "version": "0.2.0",
+  "version": "0.3.0",
   "author": "Panu Horsmalahti <panu.horsmalahti@iki.fi>",
   "description": "TypeScript compiler Gulp plugin",
   "contributors": [
@@ -27,11 +27,11 @@
     "gulpfriendly"
   ],
   "dependencies": {
-    "typescript": "~1.4.1",
-    "through": "~2.3.4",
-    "shelljs": "~0.3.0",
-    "gulp-util": "~2.2.18",
-    "rimraf": "~2.2.8"
+    "typescript": "~1.6.2",
+    "through": "~2.3.8",
+    "shelljs": "~0.5.3",
+    "gulp-util": "~3.0.7",
+    "rimraf": "~2.4.4"
   },
   "analyze": true,
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -28,17 +28,19 @@
   ],
   "dependencies": {
     "through": "~2.3.8",
-    "shelljs": "~0.5.3",
+    "shelljs": "~0.6.0",
     "gulp-util": "~3.0.7",
-    "rimraf": "~2.4.4"
+    "rimraf": "~2.5.2"
   },
   "peerDependencies": {
-    "typescript": ">=0.9"
+    "typescript": "*",
+    "gulp": ">=3.0.0"
   },
   "devDependencies": {
-    "jslint": "~0.5.2",
-    "gulp-mocha": "~0.4.1",
-    "should": "~4.0.4"
+    "jslint": "~0.9.6",
+    "gulp-mocha": "~2.2.0",
+    "should": "~8.2.2",
+    "typescript": "~1.4.1"
   },
   "license": "MIT",
   "engines": {

--- a/package.json
+++ b/package.json
@@ -27,13 +27,14 @@
     "gulpfriendly"
   ],
   "dependencies": {
-    "typescript": "~1.6.2",
     "through": "~2.3.8",
     "shelljs": "~0.5.3",
     "gulp-util": "~3.0.7",
     "rimraf": "~2.4.4"
   },
-  "analyze": true,
+  "peerDependencies": {
+    "typescript": ">=0.9"
+  },
   "devDependencies": {
     "jslint": "~0.5.2",
     "gulp-mocha": "~0.4.1",


### PR DESCRIPTION
- add `globalExe` and `exePath` options
- make TypeScript and gulp peer dependencies
- update dependencies and dev dependencies
